### PR TITLE
Support singleclick parameter

### DIFF
--- a/tapx-datefield/src/main/java/com/howardlewisship/tapx/datefield/components/DateField.java
+++ b/tapx-datefield/src/main/java/com/howardlewisship/tapx/datefield/components/DateField.java
@@ -58,6 +58,12 @@ import com.howardlewisship.tapx.datefield.services.DateFieldFormatConverter;
 public class DateField extends AbstractField
 {
     /**
+     * If true, the pop-up closes when a date is selected
+     */
+    @Parameter(defaultPrefix = BindingConstants.LITERAL)
+    private boolean singleClick = true;
+
+    /**
      * The value parameter of a DateField must be a {@link java.util.Date}.
      */
     @Parameter(required = true, principal = true, autoconnect = true)
@@ -242,7 +248,7 @@ public class DateField extends AbstractField
         writer.end(); // img
 
         JSONObject spec = new JSONObject("clientId", clientId, "clientDateFormat", formatConverter
-                .convertToClient(format)).put("time", time);
+                .convertToClient(format)).put("time", time).put("singleClick", singleClick);
 
         javascriptSupport.addInitializerCall("tapxDateField", spec);
     }

--- a/tapx-datefield/src/main/resources/com/howardlewisship/tapx/datefield/tapx-datefield.js
+++ b/tapx-datefield/src/main/resources/com/howardlewisship/tapx/datefield/tapx-datefield.js
@@ -7,6 +7,7 @@ Tapestry.Initializer.tapxDateField = function(spec)
         showsTime : spec.time,
         ifFormat : spec.clientDateFormat,
         timeFormat : spec.time && spec.clientDateFormat.match("%p") != null ? "12" : "24",
-        cache : true
+        cache : true,
+        singleClick : spec.singleClick
     });
 }


### PR DESCRIPTION
The jscalendar script supports a parameter named singleClick that controls whether the popup window closes when a date is selected. I added this parameter to the datefield component.
