### PR TITLE
Don't override yy with yyyy in explicitly specified format

### DIFF
--- a/tapx-datefield/src/main/java/com/howardlewisship/tapx/datefield/components/DateField.java
+++ b/tapx-datefield/src/main/java/com/howardlewisship/tapx/datefield/components/DateField.java
@@ -187,7 +187,7 @@ public class DateField extends AbstractField
 
                     String pattern = simpleDateFormat.toPattern();
 
-                    String revised = pattern.replaceAll("([^y])yy$", "$1yyyy");
+                    String revised = pattern.replaceAll("(?<!y)yy(?!y)", "yyyy");
 
                     return new SimpleDateFormat(revised);
                 }

--- a/tapx-datefield/src/main/java/com/howardlewisship/tapx/internal/datefield/services/DateFieldFormatConverterImpl.java
+++ b/tapx-datefield/src/main/java/com/howardlewisship/tapx/internal/datefield/services/DateFieldFormatConverterImpl.java
@@ -28,7 +28,7 @@ public class DateFieldFormatConverterImpl implements DateFieldFormatConverter
 
             // year
             "yyyy", "Y",
-            "yy", "Y",
+            "yy", "y",
 
             // month
             "MMMM", "B",

--- a/tapx-datefield/src/test/groovy/com/howardlewisship/tapx/datefield/integration/IntegrationTests.groovy
+++ b/tapx-datefield/src/test/groovy/com/howardlewisship/tapx/datefield/integration/IntegrationTests.groovy
@@ -44,7 +44,7 @@ class IntegrationTests extends SeleniumTestCase
         
         clickAndWait SUBMIT
         
-        assertFieldValue "date", "3/13/09 12:00 AM"
+        assertFieldValue "date", "3/13/2009 12:00 AM"
         assertText "outputdate", "March 13, 2009 12:00:00 AM"
     }
     
@@ -58,6 +58,6 @@ class IntegrationTests extends SeleniumTestCase
         // That's about as far as we take it; this demonstrates that the tapx DateField was used,
         // and that it picked up on the @TimeSignificant annotation.
         
-        assertFieldValue "date", "3/16/09 12:00 AM"
+        assertFieldValue "date", "3/16/2009 12:00 AM"
     }
 }

--- a/tapx-datefield/src/test/java/com/howardlewisship/tapx/internal/datefield/services/DateFieldFormatConverterImplTest.java
+++ b/tapx-datefield/src/test/java/com/howardlewisship/tapx/internal/datefield/services/DateFieldFormatConverterImplTest.java
@@ -81,10 +81,7 @@ public class DateFieldFormatConverterImplTest extends Assert
     {
         DateFormat format = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT, Locale.ENGLISH);
 
-        // Note that DateField manipulates the Java "yy" format into "yyyy" before passing into the converter.
-        // But this works because of an additional (and otherwise unnecessary) mapping from "yy".
-        
-        assertEquals(converter.convertToClient(format), "%o/%e/%Y %l:%M %p");
+        assertEquals(converter.convertToClient(format), "%o/%e/%y %l:%M %p");
     }
 
     @Test


### PR DESCRIPTION
Currently it is not possible to make the date field use a date format string containing "yy" as "yy" will be mapped to "Y" on the client side.
Also, when one is not specifying a format and the default binding will be used, the current regex replacement will only replace yy by yyyy if it is at the end of the String which will not be the case e.g. if @TimeSignificant is used on the Date.
