### PR TITLE
add a LibraryMapping for com.howardlewisship.tapx.prototype

### DIFF
--- a/tapx-prototype/src/main/java/com/howardlewisship/tapx/prototype/PrototypeModule.java
+++ b/tapx-prototype/src/main/java/com/howardlewisship/tapx/prototype/PrototypeModule.java
@@ -14,7 +14,9 @@
 
 package com.howardlewisship.tapx.prototype;
 
+import org.apache.tapestry5.ioc.Configuration;
 import org.apache.tapestry5.ioc.MappedConfiguration;
+import org.apache.tapestry5.services.LibraryMapping;
 
 public class PrototypeModule
 {
@@ -22,4 +24,10 @@ public class PrototypeModule
     {
         configuration.override("tapestry.scriptaculous.path", "com/howardlewisship/tapx/prototype");
     }
+
+    public static void contributeComponentClassResolver(final Configuration<LibraryMapping> configuration)
+    {
+        configuration.add(new LibraryMapping("tapx", "com.howardlewisship.tapx.prototype"));
+    }
+
 }


### PR DESCRIPTION
this fixes tapx-prototype being used without tapestry-core
